### PR TITLE
Move binary suffix to new units package

### DIFF
--- a/units/binary_suffix.go
+++ b/units/binary_suffix.go
@@ -1,4 +1,4 @@
-package strings
+package units
 
 import (
 	"fmt"

--- a/units/binary_suffix_test.go
+++ b/units/binary_suffix_test.go
@@ -1,4 +1,4 @@
-package strings
+package units
 
 import (
 	"github.com/stretchr/testify/assert"


### PR DESCRIPTION
A `units` package makes sense here and sounds better. Code has no other
changes.