### PR TITLE
Omit 2nd value from range

### DIFF
--- a/numbers/roman.go
+++ b/numbers/roman.go
@@ -35,7 +35,7 @@ func ToRoman(number int) (string, error) {
 	}
 
 	var sortedArabs []int
-	for arab, _ := range table {
+	for arab := range table {
 		sortedArabs = append(sortedArabs, arab)
 	}
 	sort.Sort(sort.Reverse(sort.IntSlice(sortedArabs)))


### PR DESCRIPTION
Fixed this golint:
> Line 38: warning: should omit 2nd value from range; this loop is
equivalent to `for arab := range ...` (golint)