### PR TITLE
Made a simple fix in binary_suffix

### DIFF
--- a/collection/oxford_test.go
+++ b/collection/oxford_test.go
@@ -1,8 +1,9 @@
 package collection
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOxford(t *testing.T) {

--- a/numbers/ordinal_test.go
+++ b/numbers/ordinal_test.go
@@ -1,8 +1,9 @@
 package numbers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestOrdinalizesNumbers(t *testing.T) {

--- a/numbers/roman_test.go
+++ b/numbers/roman_test.go
@@ -1,8 +1,9 @@
 package numbers
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 var workingTests = map[string]int{

--- a/strings/bool_test.go
+++ b/strings/bool_test.go
@@ -1,8 +1,9 @@
 package strings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestToBool(t *testing.T) {
@@ -16,7 +17,7 @@ func TestToBool(t *testing.T) {
 		"on":    true,
 		"off":   false,
 		"1":     true,
-		"0":     false,		
+		"0":     false,
 	}
 
 	for input, expected := range tests {

--- a/strings/camelize_test.go
+++ b/strings/camelize_test.go
@@ -1,8 +1,9 @@
 package strings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestCamelize(t *testing.T) {

--- a/strings/humanize_test.go
+++ b/strings/humanize_test.go
@@ -1,8 +1,9 @@
 package strings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestHumanize(t *testing.T) {

--- a/strings/truncate_test.go
+++ b/strings/truncate_test.go
@@ -1,8 +1,9 @@
 package strings
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestTruncate(t *testing.T) {

--- a/units/binary_suffix.go
+++ b/units/binary_suffix.go
@@ -11,39 +11,31 @@ const BinaryConvertThreshold = 1024
 
 // BinarySuffix returns the given number with a binary suffix.
 func BinarySuffix(number float64) string {
-	str := ""
+	var str string
 	if number < 0 {
-		str += "-"
+		str = "-"
 		number = math.Abs(number)
 	}
-
 	var binarySuffixPrefixes = map[float64]string{
 		1125899906842624: "%.2f PB",
 		1099511627776:    "%.2f TB",
 		1073741824:       "%.2f GB",
 		1048576:          "%.2f MB",
 		1024:             "%.1f kB",
-		0:                "%.0f bytes",
 	}
-
 	intSlice := make([]float64, 0, len(binarySuffixPrefixes))
 	for num := range binarySuffixPrefixes {
 		intSlice = append(intSlice, num)
 	}
 	sort.Sort(sort.Reverse(sort.Float64Slice(intSlice)))
-
 	for _, size := range intSlice {
 		if size <= number {
 			var value float64
 			if number >= BinaryConvertThreshold {
 				value = number / float64(size)
-			} else {
-				value = number
 			}
-
 			return str + fmt.Sprintf(binarySuffixPrefixes[size], value)
 		}
 	}
-
-	return str + fmt.Sprintf("%f", number)
+	return fmt.Sprintf("%s%.0f bytes", str, number)
 }

--- a/units/binary_suffix_test.go
+++ b/units/binary_suffix_test.go
@@ -1,8 +1,9 @@
 package units
 
 import (
-	"github.com/stretchr/testify/assert"
 	"testing"
+
+	"github.com/stretchr/testify/assert"
 )
 
 func TestBinarySuffix(t *testing.T) {
@@ -15,7 +16,7 @@ func TestBinarySuffix(t *testing.T) {
 		1048576 * 5:       "5.00 MB",
 		1073741824 * 2:    "2.00 GB",
 		1099511627776 * 3: "3.00 TB",
-		1325899906842624:  "1.18 PB",
+		1325899906842623:  "1.18 PB",
 		-5:                "-5 bytes",
 		-1.49:             "-1 bytes",
 		-2.8:              "-3 bytes",


### PR DESCRIPTION
Improved readablity and fallback functionality for the
`units.BinarySuffix` function.