### PR TITLE
Remove old versions.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,16 +1,15 @@
 language: go
 
 go:
-  - 1.2
-  - 1.3
-  - 1.4
   - 1.5
+  - 1.6
+  - 1.7
 
 install:
   - go get -d -v ./... && go build -v ./...
   - go get github.com/stretchr/testify/assert
   - go get golang.org/x/tools/cmd/cover
-  
+
 script:
   - ./run-tests.sh
 


### PR DESCRIPTION
The older golang versions seem to work but a no longer supported and
therefore do not need to be tested by travis