### PR TITLE
Fix Oxford Collection

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: go
 
 go:
-  - 1.10
+  - "1.10"
   - 1.11
   - 1.12
+  - tip
 
 install:
   - go get -d -v ./... && go build -v ./...
@@ -11,7 +12,7 @@ install:
   - go get golang.org/x/tools/cmd/cover
 
 script:
-  - go test -race -coverprofile=coverage.txt -covermode=atomic
+  - ./run-tests.sh
 
 after_success:
   - curl -s https://codecov.io/bash | bash

--- a/collection/oxford.go
+++ b/collection/oxford.go
@@ -36,11 +36,11 @@ func formatOnlyTwo(collection []string) string {
 func formatCommaSeparatedWithLimit(collection []string, limit int, count int) string {
 	display := strings.Join(collection[:limit], ", ")
 	moreCount := count - limit
-	return display + " and " + strconv.Itoa(moreCount) + " more"
+	return display + ", and " + strconv.Itoa(moreCount) + " more"
 }
 
 // Format without limit
 func formatCommaSeparated(collection []string, count int) string {
 	display := strings.Join(collection[:(count-1)], ", ")
-	return display + " and " + collection[(count-1)]
+	return display + ", and " + collection[(count-1)]
 }

--- a/collection/oxford.go
+++ b/collection/oxford.go
@@ -5,7 +5,7 @@ import (
 	"strings"
 )
 
-// Oxford returns a string from a string collection by adding ", " as a seperator and the word "and" for the last seperator.
+// Oxford returns a string from a string collection by adding ", " as a separator and the word "and" for the last separator.
 // A limit will print all elements to the limit and elements after the limit will be grouped with a "and n more".
 // No limit is represented with with a limit <= 0
 func Oxford(collection []string, limit int) string {

--- a/collection/oxford_test.go
+++ b/collection/oxford_test.go
@@ -18,6 +18,6 @@ func TestOxford(t *testing.T) {
 
 	assert.Equal(t, "Albert", Oxford(testCollection[:1], -1))
 	assert.Equal(t, "Albert and Norbert", Oxford(testCollection[:2], -1))
-	assert.Equal(t, "Albert, Norbert, Michael and Kevin", Oxford(testCollection, -1))
-	assert.Equal(t, "Albert, Norbert and 2 more", Oxford(testCollection, 2))
+	assert.Equal(t, "Albert, Norbert, Michael, and Kevin", Oxford(testCollection, -1))
+	assert.Equal(t, "Albert, Norbert, and 2 more", Oxford(testCollection, 2))
 }


### PR DESCRIPTION
Oxford collections need a comma between the last listing element and the
"and" word.
> Albert, Kevin, and Peter

We were missing the command before the and.

No related issue present